### PR TITLE
Detaches child process from the parent

### DIFF
--- a/src/HandlerAbstract.php
+++ b/src/HandlerAbstract.php
@@ -27,7 +27,8 @@ abstract class HandlerAbstract implements HandlerInterface
             'status' => 'running',
             'percent' => 0,
             'host' => trim(shell_exec('hostname')),
-            'pid' => posix_getpid()
+            'pid' => posix_getpid(),
+            'sid' => posix_getsid(posix_getpid()),
         ]);
     }
 

--- a/src/Task.php
+++ b/src/Task.php
@@ -7,7 +7,7 @@ class Task
     private $handler;
     private $task;
     private $args;
-
+    private $sid;
     private $started = false;
 
     public function __construct(HandlerInterface $handler, callable $task, array $args = [])
@@ -73,6 +73,7 @@ class Task
         } else {
             /**
              * Child
+             * We're detaching the child process from the parent so that if the main fpm restarts or is killed our process can continue. 
              */
             
             $sid = posix_setsid();
@@ -80,7 +81,7 @@ class Task
             if ($sid < 0) {
                 exit();
             }
-            
+            $this->setSid($sid);
             register_shutdown_function(function () {
                 $error = error_get_last();
                 // @TODO why are we only logging this set of exceptions? do we ever not have non 1/256/4096 error codes
@@ -135,7 +136,15 @@ class Task
         }
         // @codeCoverageIgnoreEnd
     }
+    private function setSID($sid) 
+    {
+        $this->sid = $sid;
+    }
 
+    public function getSID() 
+    {
+        return $this->sid;
+    }
     // @codeCoverageIgnoreStart
     private function kill()
     {

--- a/src/Task.php
+++ b/src/Task.php
@@ -74,6 +74,13 @@ class Task
             /**
              * Child
              */
+            
+            $sid = posix_setsid();
+            
+            if ($sid < 0) {
+                exit();
+            }
+            
             register_shutdown_function(function () {
                 $error = error_get_last();
                 // @TODO why are we only logging this set of exceptions? do we ever not have non 1/256/4096 error codes

--- a/src/Task.php
+++ b/src/Task.php
@@ -41,7 +41,6 @@ class Task
                 break;
             }
         } // @codeCoverageIgnore
-        //@TODO why are we ignoring code coverage here? 
         // @codeCoverageIgnoreStart
         //
         $pid = pcntl_fork();
@@ -79,6 +78,7 @@ class Task
             $sid = posix_setsid();
             
             if ($sid < 0) {
+                // if we're not able to detach from the parent then we should exit
                 exit();
             }
             $this->setSid($sid);

--- a/tests/HandlerAbstractTest.php
+++ b/tests/HandlerAbstractTest.php
@@ -25,7 +25,7 @@ class HandlerAbstractTest extends PHPUnit_Framework_TestCase
         $this->handler->afterFork();
         $taskData = $this->handler->get();
 
-        $this->assertSame(array_keys($taskData), ['timestampStart', 'status', 'percent', 'host', 'pid']);
+        $this->assertSame(array_keys($taskData), ['timestampStart', 'status', 'percent', 'host', 'pid', 'sid']);
 
         $this->assertSame($taskData['status'], 'running');
         $this->assertSame($taskData['percent'], 0);

--- a/tests/TaskTest.php
+++ b/tests/TaskTest.php
@@ -36,6 +36,30 @@ class TaskTest extends PHPUnit_Framework_TestCase
 
         $handler->cleanup();
     }
+    public function testRunSeparateSid()
+    {
+        $handler = new TaskTestHandler();
+
+        $task = new Task($handler, function (HandlerInterface $handler) {
+            sleep(1);
+            $handler->writeLog('testRun');
+            $handler->complete();
+        });
+
+        $task->run();
+        $childSid = $task->getSID();
+        usleep(200 * 1000);
+        $pid = $handler->get('pid');
+        $sid = $handler->get('sid');
+
+        sleep(1);
+        $this->assertNotSame($childSid, $sid);
+
+        pcntl_waitpid($pid, $status);
+
+
+        $handler->cleanup();
+    }
 
     public function testCallableNameString()
     {

--- a/tests/TaskTest.php
+++ b/tests/TaskTest.php
@@ -73,7 +73,7 @@ class TaskTest extends PHPUnit_Framework_TestCase
 
         $pid = $handler->get('pid');
 
-        sleep(1);
+        sleep(2);
 
         $this->assertSame($handler->getStatus(), 'complete');
         $this->assertSame($handler->get('callableName'), 'MyTask::taskStatic');

--- a/tests/TaskTest.php
+++ b/tests/TaskTest.php
@@ -118,7 +118,7 @@ class TaskTest extends PHPUnit_Framework_TestCase
 
         $pid = $handler->get('pid');
 
-        sleep(1);
+        sleep(2);
 
         $this->assertSame($handler->getStatus(), 'complete');
         $this->assertSame($handler->get('callableName'), 'MyTask::taskStatic');


### PR DESCRIPTION
This separates the child process from the parent by setting a new session id. 

_NOTE_ you need to make sure you are using a sock for php-fpm, if fpm is bound to a port restarting the parent won't allow it to reattach. 
